### PR TITLE
feat: package mise from pre-built binaries

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,22 +254,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-mise": {
-      "locked": {
-        "lastModified": 1773734432,
-        "narHash": "sha256-IF5ppUWh6gHGHYDbtVUyhwy/i7D261P7fWD1bPefOsw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "cda48547b432e8d3b18b4180ba07473762ec8558",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "cda48547",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1735563628,
@@ -345,7 +329,6 @@
         "nix-colors": "nix-colors",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixpkgs": "nixpkgs_4",
-        "nixpkgs-mise": "nixpkgs-mise",
         "nixpkgs-stable": "nixpkgs-stable",
         "sops-nix": "sops-nix",
         "systems": "systems_2"

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
-    nixpkgs-mise.url = "github:nixos/nixpkgs/cda48547";
     flake-utils.url = "github:numtide/flake-utils";
     systems.url = "github:nix-systems/default";
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -24,17 +24,9 @@
     (import ../pkgs {pkgs = final;})
     // {
       claude-code = final.callPackage ../pkgs/claude-code {};
+      mise = final.callPackage ../pkgs/mise {};
     };
 
-  # This one contains whatever you want to overlay
-  # You can change versions, add patches, set compilation flags, anything really.
-  # https://nixos.wiki/wiki/Overlays
-  modifications = final: prev: {
-    mise =
-      (import inputs.nixpkgs-mise {
-        system = final.stdenv.hostPlatform.system;
-      }).mise;
-  };
   # access stable packages as pkgs.stable
   stable-packages = final: _prev: {
     stable = import inputs.nixpkgs-stable {

--- a/pkgs/mise/default.nix
+++ b/pkgs/mise/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}: let
+  version = "2026.4.3";
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-linux-x64-musl";
+      hash = "sha256-f6CMYz2wQAtb8G/7XKNXBi2DwH2GoBdJtdlnI8Y+aHI=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-linux-arm64-musl";
+      hash = "sha256-bwt5L3QA9Im66Yp42nbTdmxivH0skYu3hVtUWoV70lw=";
+    };
+    aarch64-darwin = {
+      url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-macos-arm64";
+      hash = "sha256-0LhpmrAEhT8Z+QP5fU7WZoX0CXUa4oOJ/wbzW2CsJUM=";
+    };
+  };
+  src = sources.${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+in
+  stdenv.mkDerivation {
+    pname = "mise";
+    inherit version;
+
+    src = fetchurl {
+      inherit (src) url hash;
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      install -Dm755 $src $out/bin/mise
+    '';
+
+    meta = with lib; {
+      description = "Dev tools, env vars, task runner";
+      homepage = "https://mise.jdx.dev";
+      license = licenses.mit;
+      mainProgram = "mise";
+      platforms = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
+    };
+  }


### PR DESCRIPTION
## Summary
- Add `pkgs/mise/default.nix` — fetches platform-appropriate pre-built binary from GitHub releases (musl on Linux, standard on macOS) for mise v2026.4.3
- Wire into `overlays/default.nix` additions overlay via `callPackage`, consistent with `claude-code` pattern
- Remove `nixpkgs-mise` pinned-commit flake input and the `modifications.mise` overlay block

## Test Plan
- [ ] `just lint` passes (nix fmt check + nix flake check)
- [ ] `mise --version` outputs `2026.4.3` on the target system