### PR TITLE
feat: add sonic-pi

### DIFF
--- a/homes/_modules/daw/default.nix
+++ b/homes/_modules/daw/default.nix
@@ -7,6 +7,7 @@
     packages = with pkgs; [
       reaper
       renoise
+      sonic-pi
     ];
   };
 }

--- a/homes/olivertosky/ot-framework.nix
+++ b/homes/olivertosky/ot-framework.nix
@@ -12,6 +12,7 @@
     ../_modules/kubernetes
     ../_modules/developer
     ../_modules/extra
+    ../_modules/daw
   ];
 
   modules = {

--- a/hosts/common/base/default.nix
+++ b/hosts/common/base/default.nix
@@ -33,6 +33,9 @@
       permittedInsecurePackages = [
         "electron-27.3.11"
       ];
+      problems.handlers = {
+        sonic-pi.broken = "ignore";
+      };
     };
   };
 


### PR DESCRIPTION
Adds `sonic-pi` to the daw module and enables the daw module on `ot-framework`. Includes a targeted `problems.handlers.sonic-pi.broken = "ignore"` override since sonic-pi 4.6.0 is marked broken in nixpkgs.

<!-- branch-stack-start -->

<!-- branch-stack-end -->
