### PR TITLE
feat: add tidal cycles support

### DIFF
--- a/homes/_modules/daw/default.nix
+++ b/homes/_modules/daw/default.nix
@@ -1,5 +1,4 @@
 {
-  config,
   pkgs,
   ...
 }: {
@@ -7,6 +6,13 @@
     packages = with pkgs; [
       reaper
       renoise
+      supercollider
+      haskellPackages.tidal
     ];
+  };
+
+  xdg.dataFile = {
+    "SuperCollider/Quarks/SuperDirt".source = "${pkgs.superdirt}/SuperDirt";
+    "SuperCollider/Quarks/Dirt-Samples".source = "${pkgs.superdirt}/Dirt-Samples";
   };
 }

--- a/homes/_modules/daw/default.nix
+++ b/homes/_modules/daw/default.nix
@@ -4,7 +4,6 @@
       reaper
       renoise
       supercollider
-      haskellPackages.tidal
     ];
   };
 

--- a/homes/_modules/daw/default.nix
+++ b/homes/_modules/daw/default.nix
@@ -1,7 +1,4 @@
-{
-  pkgs,
-  ...
-}: {
+{pkgs, ...}: {
   home = {
     packages = with pkgs; [
       reaper

--- a/homes/_modules/editor/neovim/nvim/lua/plugins/tidal.lua
+++ b/homes/_modules/editor/neovim/nvim/lua/plugins/tidal.lua
@@ -1,0 +1,6 @@
+return {
+  {
+    "tidalcycles/vim-tidal",
+    ft = "tidal",
+  },
+}

--- a/homes/_modules/shell/fish/functions/tidal_new.fish
+++ b/homes/_modules/shell/fish/functions/tidal_new.fish
@@ -1,0 +1,7 @@
+function tidal_new
+    if test (count $argv) -eq 0
+        echo "Usage: tidal_new <project-name>"
+        return 1
+    end
+    nix flake new --template github:mitchmindtree/tidalcycles.nix#templates.default $argv[1]
+end

--- a/homes/olivertosky/ot-framework.nix
+++ b/homes/olivertosky/ot-framework.nix
@@ -12,6 +12,7 @@
     ../_modules/kubernetes
     ../_modules/developer
     ../_modules/extra
+    ../_modules/daw
   ];
 
   modules = {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,4 +3,5 @@
 {pkgs}: {
   # example = pkgs.callPackage ./example { };
   agor = pkgs.callPackage ./agor {};
+  superdirt = pkgs.callPackage ./superdirt {};
 }

--- a/pkgs/superdirt/default.nix
+++ b/pkgs/superdirt/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+let
+  superdirt-src = fetchFromGitHub {
+    owner = "musikinformatik";
+    repo = "SuperDirt";
+    rev = "v1.7.4";
+    hash = "sha256-9qU9CHYAXbN1IE3xXDqGipuroifVaSVXj3c/cDfwM80=";
+  };
+  dirt-samples-src = fetchFromGitHub {
+    owner = "tidalcycles";
+    repo = "Dirt-Samples";
+    rev = "e6f801712fe7f4753ebedc04afa544e34c2f9501";
+    hash = "sha256-OzVvy/L6jfEgGx3dMdhe/PkfMAWVV0HQ9wGy500++fw=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "superdirt";
+  version = "1.7.4";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/SuperDirt $out/Dirt-Samples
+    cp -r ${superdirt-src}/. $out/SuperDirt/
+    cp -r ${dirt-samples-src}/. $out/Dirt-Samples/
+  '';
+
+  meta = with lib; {
+    description = "SuperDirt audio engine and samples for TidalCycles";
+    homepage = "https://github.com/musikinformatik/SuperDirt";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/superdirt/default.nix
+++ b/pkgs/superdirt/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation {
     description = "SuperDirt audio engine and samples for TidalCycles";
     homepage = "https://github.com/musikinformatik/SuperDirt";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/superdirt/default.nix
+++ b/pkgs/superdirt/default.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-}:
-let
+}: let
   superdirt-src = fetchFromGitHub {
     owner = "musikinformatik";
     repo = "SuperDirt";
@@ -17,22 +16,22 @@ let
     hash = "sha256-OzVvy/L6jfEgGx3dMdhe/PkfMAWVV0HQ9wGy500++fw=";
   };
 in
-stdenv.mkDerivation {
-  pname = "superdirt";
-  version = "1.7.4";
+  stdenv.mkDerivation {
+    pname = "superdirt";
+    version = "1.7.4";
 
-  dontUnpack = true;
+    dontUnpack = true;
 
-  installPhase = ''
-    mkdir -p $out/SuperDirt $out/Dirt-Samples
-    cp -r ${superdirt-src}/. $out/SuperDirt/
-    cp -r ${dirt-samples-src}/. $out/Dirt-Samples/
-  '';
+    installPhase = ''
+      mkdir -p $out/SuperDirt $out/Dirt-Samples
+      cp -r ${superdirt-src}/. $out/SuperDirt/
+      cp -r ${dirt-samples-src}/. $out/Dirt-Samples/
+    '';
 
-  meta = with lib; {
-    description = "SuperDirt audio engine and samples for TidalCycles";
-    homepage = "https://github.com/musikinformatik/SuperDirt";
-    license = licenses.gpl2Only;
-    platforms = platforms.unix;
-  };
-}
+    meta = with lib; {
+      description = "SuperDirt audio engine and samples for TidalCycles";
+      homepage = "https://github.com/musikinformatik/SuperDirt";
+      license = licenses.gpl2Only;
+      platforms = platforms.unix;
+    };
+  }


### PR DESCRIPTION
## Summary

- Add custom `superdirt` package with SuperDirt quarks and samples wired into `~/.local/share/SuperCollider/Quarks/`
- Add `daw` home-manager module with SuperCollider, Reaper, and Renoise; enabled for `ot-framework`
- Add `vim-tidal` neovim plugin for evaluating patterns from `.tidal` files
- Add `tidal_new` fish function to scaffold new tidal projects from the `mitchmindtree/tidalcycles.nix` flake template

## Test plan

- [ ] Rebuild `ot-framework` and verify `sclang` is available
- [ ] Run `tidal_new my-project` and confirm flake template is scaffolded
- [ ] Open SuperCollider, run `SuperDirt.start`, open a `.tidal` file in neovim and evaluate a pattern with `<C-e>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)