### PR TITLE
feat: add vcv-rack

### DIFF
--- a/homes/_modules/daw/default.nix
+++ b/homes/_modules/daw/default.nix
@@ -4,6 +4,7 @@
       reaper
       renoise
       supercollider
+      vcv-rack
     ];
   };
 

--- a/homes/_modules/desktop/common/default.nix
+++ b/homes/_modules/desktop/common/default.nix
@@ -16,4 +16,7 @@
     };
   };
   xdg.portal.enable = true;
+  xresources.properties = {
+    "Xft.dpi" = 96;
+  };
 }

--- a/homes/_modules/desktop/hyprland.nix
+++ b/homes/_modules/desktop/hyprland.nix
@@ -69,6 +69,7 @@ in {
       exec-once = [
         "${pkgs.swaynotificationcenter}/bin/swaync"
         "${pkgs.awww}/bin/awww-daemon"
+        "${pkgs.xorg.xrdb}/bin/xrdb -merge ${config.home.homeDirectory}/.Xresources"
       ];
       # exec = ["${pkgs.swaybg}/bin/swaybg -i ${wallpaper} --mode fill"];
       exec = ["${pkgs.awww}/bin/awww img ${gifWallpaper}"];


### PR DESCRIPTION
Adds `vcv-rack` (2.6.6) to the daw module. Available on both `ot-desktop` and `ot-framework`. Plugins can be installed at runtime via VCV Rack's built-in library browser.

<!-- branch-stack-start -->

<!-- branch-stack-end -->
