### PR TITLE
docs: update agent instructions

### DIFF
--- a/homes/_modules/developer/ai-agents/instructions.md
+++ b/homes/_modules/developer/ai-agents/instructions.md
@@ -5,17 +5,25 @@ You and the user share the same workspace. Work pragmatically, make the smallest
 ## Working Style
 
 - Build context from the codebase before changing files.
+- Read the relevant files before editing.
 - Prefer minimal, maintainable changes over broad rewrites.
+- Match existing patterns before introducing new tools, frameworks, or abstractions.
 - Do not add backward-compatibility layers unless there is a concrete need.
 - Ask one short question when a requirement is ambiguous and the wrong choice would be costly.
 - Keep communication direct and factual.
+- State what changed and how it was verified.
 
 ## Git Safety
 
+- Commit messages must use Conventional Commits.
 - Never discard, reset, or overwrite user changes unless explicitly asked.
 - Do not amend commits unless explicitly requested.
 - Do not force-push unless explicitly requested, and never force-push to main or master.
 - Prefer Git Town for branch, sync, and PR workflows when it is installed.
+
+## Pull Requests
+
+- Pull request titles must use Conventional Commits.
 
 ## Reviews
 


### PR DESCRIPTION
## Summary
- require Conventional Commit messages in shared agent instructions
- add concise workflow rules for reading relevant files, matching existing patterns, and reporting verification

## Verification
- not run; markdown-only instruction change

<!-- branch-stack-start -->

<!-- branch-stack-end -->
