### PR TITLE
fix: repair pdm and pi-coding-agent builds broken by flake update

### DIFF
--- a/homes/_modules/developer/default.nix
+++ b/homes/_modules/developer/default.nix
@@ -21,7 +21,7 @@
         gnumake
         go
         uv
-        pdm
+        stable.pdm
         duckdb
         stable.pgcli
         changie

--- a/pkgs/pi-coding-agent/default.nix
+++ b/pkgs/pi-coding-agent/default.nix
@@ -23,6 +23,11 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [typescript-go];
 
+  postPatch = ''
+    substituteInPlace tsconfig.base.json \
+      --replace-fail '"ES2022"' '"ES2024"'
+  '';
+
   buildPhase = ''
     runHook preBuild
     tsgo -p packages/ai/tsconfig.build.json


### PR DESCRIPTION
## Summary

- **pdm**: `pdm 2.26.6` declares `installer<0.8,>=0.7` but nixpkgs-unstable now ships `installer 1.0.0`, causing a runtime dependency check failure. Pinned to `stable.pdm` (2.15.3) which builds cleanly.
- **pi-coding-agent**: `packages/tui/src/utils.ts` uses the `/v` regex flag (Unicode sets), which TypeScript requires a target of `ES2024` or later. The upstream `tsconfig.base.json` targets `ES2022` and `tsgo` now correctly enforces the spec. Added a `postPatch` to bump the target to `ES2024` at build time.

## Test plan

- [ ] `nix build .#nixosConfigurations.ot-framework.config.system.build.toplevel` passes
- [ ] `nix build .#nixosConfigurations.ot-desktop.config.system.build.toplevel` passes

<!-- branch-stack-start -->

<!-- branch-stack-end -->
