### PR TITLE
fix: Update LazyVim navigation and AI config

### DIFF
--- a/homes/_modules/editor/neovim/nvim/lua/plugins/ai.lua
+++ b/homes/_modules/editor/neovim/nvim/lua/plugins/ai.lua
@@ -1,0 +1,15 @@
+return {
+  {
+    "folke/sidekick.nvim",
+    opts = {
+      -- Keep Sidekick's CLI integrations, but never start/configure Copilot NES.
+      nes = { enabled = false },
+      copilot = {
+        status = {
+          enabled = false,
+          level = vim.log.levels.OFF,
+        },
+      },
+    },
+  },
+}

--- a/homes/_modules/editor/neovim/nvim/lua/plugins/core.lua
+++ b/homes/_modules/editor/neovim/nvim/lua/plugins/core.lua
@@ -14,6 +14,28 @@ return {
 
   -- disable any unwanted default LazyVim plugs
   { "akinsho/bufferline.nvim", enabled = false },
-  { "ggandor/leap.nvim", enabled = false },
-  { "ggandor/flit.nvim", enabled = false },
+
+  {
+    "folke/flash.nvim",
+    keys = {
+      { "s", false, mode = { "n", "x", "o" } },
+      { "S", false, mode = { "n", "x", "o" } },
+      {
+        "<leader>j",
+        mode = { "n", "x", "o" },
+        function()
+          require("flash").jump()
+        end,
+        desc = "Flash",
+      },
+      {
+        "<leader>J",
+        mode = { "n", "x", "o" },
+        function()
+          require("flash").treesitter()
+        end,
+        desc = "Flash Treesitter",
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Summary
- remove stale disabled ggandor Leap/Flit specs now that LazyVim defaults to Flash
- remap Flash from `s`/`S` to `<leader>j`/`<leader>J` so stock substitute bindings work again
- add dedicated AI plugin config that keeps Sidekick CLI integrations while disabling Copilot NES/status notifications

## Validation
- `stylua homes/_modules/editor/neovim/nvim/lua/plugins/core.lua homes/_modules/editor/neovim/nvim/lua/plugins/ai.lua`
- headless Neovim config check: Sidekick present, Copilot LSP absent, NES/status disabled, `s`/`S` free, Flash on `<leader>j`/`<leader>J`


<!-- branch-stack-start -->

<!-- branch-stack-end -->
