### PR TITLE
chore(ai-agents): require conventional PR titles

### DIFF
--- a/homes/_modules/developer/ai-agents/default.nix
+++ b/homes/_modules/developer/ai-agents/default.nix
@@ -9,11 +9,15 @@ in {
     ".claude/skills/git-town/SKILL.md".source = ./skills/git-town/SKILL.md;
     ".agents/skills/git-town/SKILL.md".source = ./skills/git-town/SKILL.md;
 
-    ".pi/agent" = {
+    ".pi/agent/AGENTS.md".source = ./instructions.md;
+
+    ".pi/agent/extensions" = {
       force = true;
       recursive = true;
-      source = ./pi;
+      source = ./pi/extensions;
     };
+
+    ".pi/agent/keybindings.json".source = ./pi/keybindings.json;
 
     ".codex/config.toml" = {
       # Codex only reads a single config.toml. Keep the known mutable NUX key

--- a/homes/_modules/developer/ai-agents/instructions.md
+++ b/homes/_modules/developer/ai-agents/instructions.md
@@ -23,7 +23,13 @@ You and the user share the same workspace. Work pragmatically, make the smallest
 
 ## Pull Requests
 
-- Pull request titles must use Conventional Commits.
+- Before creating a pull request, check the repository's `CONTRIBUTING.md` and `README.md` for project-specific PR title guidance. Follow those guidelines if they conflict with these defaults.
+- Otherwise, pull request titles must use Conventional Commits: `type(scope): summary`, `type: summary`, or `type!: summary`.
+- Allowed PR title types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`.
+- Scopes are optional but encouraged when they add useful context.
+- Synthesize the PR title from the actual diff, not just the branch name or first commit.
+- Make your best call on title type/scope without asking; the user can edit the PR later.
+- Use `chore` for dependency, Nix, and routine maintenance updates unless another type is clearly more accurate.
 
 ## Reviews
 

--- a/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
+++ b/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
@@ -33,11 +33,21 @@ Workflow:
 
 ### Creating PRs (git town propose)
 
-When running non-interactively, ALWAYS provide `--title` and `--body`:
+Before creating a PR, check the repository's `CONTRIBUTING.md` and `README.md` for project-specific PR title guidance. Follow those guidelines if they conflict with these defaults.
+
+When running non-interactively, ALWAYS provide `--title` and `--body`. The title must use Conventional Commits unless project-specific guidance says otherwise:
 
 ```
-git town propose --title "feat: description" --body "PR body here"
+git town propose --title "feat(scope): description" --body "PR body here"
 ```
+
+PR title rules:
+
+- Use one of: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`.
+- Scopes are optional but encouraged when useful.
+- Synthesize the title from the actual diff, not just the branch name or first commit.
+- Make the best type/scope call without asking; the user can edit the PR later.
+- Use `chore` for dependency, Nix, and routine maintenance updates unless another type is clearly more accurate.
 
 Common flags:
 


### PR DESCRIPTION
## Summary
- expand shared agent PR guidance to require Conventional Commit titles by default
- update the Git Town skill with the same PR title rules
- expose shared instructions to Pi via AGENTS.md while keeping Pi extensions/keybindings wired separately

## Verification
- nix eval '.#homeConfigurations."oliver.tosky@MAC-T1699DT90K".activationPackage.drvPath'


<!-- branch-stack-start -->

<!-- branch-stack-end -->
