### PR TITLE
chore: sync boot generation limit with nix gc

### DIFF
--- a/hosts/common/base/nix.nix
+++ b/hosts/common/base/nix.nix
@@ -5,7 +5,10 @@
   ...
 }: let
   flakeInputs = lib.filterAttrs (_: lib.isType "flake") inputs;
+  keptGenerations = 3;
 in {
+  boot.loader.systemd-boot.configurationLimit = keptGenerations;
+
   nix = {
     package = pkgs.nixVersions.nix_2_28;
 
@@ -33,7 +36,7 @@ in {
       automatic = true;
       dates = "weekly";
       # Keep the last 3 generations
-      options = "--delete-older-than +3";
+      options = "--delete-older-than +${toString keptGenerations}";
     };
 
     registry = lib.mapAttrs (_: flake: {inherit flake;}) flakeInputs;


### PR DESCRIPTION
## Summary
- add a shared keptGenerations value for Nix GC and systemd-boot
- set systemd-boot configurationLimit to match the GC generation count

## Verification
- nix eval .#nixosConfigurations.ot-framework.config.boot.loader.systemd-boot.configurationLimit
- nix eval .#nixosConfigurations.ot-desktop.config.boot.loader.systemd-boot.configurationLimit

<!-- branch-stack-start -->

<!-- branch-stack-end -->
