### PR TITLE
feat(ai-agents): add web search extension for pi

### DIFF
--- a/homes/_modules/developer/ai-agents/pi/extensions/web-search.ts
+++ b/homes/_modules/developer/ai-agents/pi/extensions/web-search.ts
@@ -1,0 +1,90 @@
+import { Type } from "@mariozechner/pi-ai";
+import type { AgentToolResult, ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type SearchResult = {
+	title: string;
+	url: string;
+	snippet: string;
+};
+
+async function searchTavily(query: string, maxResults: number, apiKey: string): Promise<SearchResult[]> {
+	const res = await fetch("https://api.tavily.com/search", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ query, max_results: maxResults, api_key: apiKey }),
+	});
+	if (!res.ok) throw new Error(`Tavily: HTTP ${res.status}`);
+	const data = (await res.json()) as {
+		results?: Array<{ title?: string; url?: string; content?: string }>;
+	};
+	return (data.results ?? []).slice(0, maxResults).map((r) => ({
+		title: r.title ?? "",
+		url: r.url ?? "",
+		snippet: (r.content ?? "").slice(0, 300),
+	}));
+}
+
+async function searchBrave(query: string, maxResults: number, apiKey: string): Promise<SearchResult[]> {
+	const res = await fetch(
+		`https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${maxResults}`,
+		{ headers: { Accept: "application/json", "X-Subscription-Token": apiKey } },
+	);
+	if (!res.ok) throw new Error(`Brave Search: HTTP ${res.status}`);
+	const data = (await res.json()) as {
+		web?: { results?: Array<{ title?: string; url?: string; description?: string }> };
+	};
+	return (data.web?.results ?? []).slice(0, maxResults).map((r) => ({
+		title: r.title ?? "",
+		url: r.url ?? "",
+		snippet: r.description ?? "",
+	}));
+}
+
+function formatResults(results: SearchResult[], query: string): string {
+	if (results.length === 0) return `No results found for: "${query}"`;
+	return results.map((r, i) => `${i + 1}. **${r.title}**\n   ${r.url}\n   ${r.snippet}`).join("\n\n");
+}
+
+async function doSearch(query: string, maxResults: number): Promise<SearchResult[]> {
+	const tavilyKey = process.env.TAVILY_API_KEY;
+	if (tavilyKey) return searchTavily(query, maxResults, tavilyKey);
+	const braveKey = process.env.BRAVE_SEARCH_API_KEY;
+	if (braveKey) return searchBrave(query, maxResults, braveKey);
+	throw new Error("No search provider configured. Set TAVILY_API_KEY or BRAVE_SEARCH_API_KEY.");
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "web_search",
+		label: "Web Search",
+		description:
+			"Searches the web for up-to-date information beyond your knowledge cutoff. Prefer primary sources (official docs, papers, announcements) and corroborate key claims with multiple sources. Always include links for cited sources in your response.",
+		promptSnippet: "web_search(query) — fetch current information from the web",
+		promptGuidelines: [
+			"If unsure about a fact, search instead of guessing.",
+			"Prefer primary sources (official docs, specs, papers) over blog summaries or aggregators.",
+			"Note publication dates when recency affects relevance; prefer recent sources for time-sensitive topics.",
+			"When sources conflict, acknowledge the discrepancy and note which seems more authoritative.",
+			"Always cite sources inline and include links in your final response.",
+		],
+		parameters: Type.Object({
+			query: Type.String({ description: "Web search query" }),
+			maxResults: Type.Optional(
+				Type.Integer({
+					description: "Maximum results to return (1–10, default 5)",
+					minimum: 1,
+					maximum: 10,
+					default: 5,
+				}),
+			),
+		}),
+		async execute(_id, { query, maxResults }, _signal, _onUpdate, _ctx): Promise<AgentToolResult<SearchResult[]>> {
+			const results = await doSearch(query, maxResults ?? 5);
+			return {
+				content: [{ type: "text", text: formatResults(results, query) }],
+				details: results,
+			};
+		},
+	});
+
+}

--- a/homes/_modules/developer/ai-agents/pi/extensions/web-search.ts
+++ b/homes/_modules/developer/ai-agents/pi/extensions/web-search.ts
@@ -1,5 +1,5 @@
-import { Type } from "@mariozechner/pi-ai";
 import type { AgentToolResult, ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
 
 type SearchResult = {
 	title: string;
@@ -7,11 +7,12 @@ type SearchResult = {
 	snippet: string;
 };
 
-async function searchTavily(query: string, maxResults: number, apiKey: string): Promise<SearchResult[]> {
+async function searchTavily(query: string, maxResults: number, apiKey: string, signal?: AbortSignal): Promise<SearchResult[]> {
 	const res = await fetch("https://api.tavily.com/search", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ query, max_results: maxResults, api_key: apiKey }),
+		signal,
 	});
 	if (!res.ok) throw new Error(`Tavily: HTTP ${res.status}`);
 	const data = (await res.json()) as {
@@ -24,10 +25,10 @@ async function searchTavily(query: string, maxResults: number, apiKey: string): 
 	}));
 }
 
-async function searchBrave(query: string, maxResults: number, apiKey: string): Promise<SearchResult[]> {
+async function searchBrave(query: string, maxResults: number, apiKey: string, signal?: AbortSignal): Promise<SearchResult[]> {
 	const res = await fetch(
 		`https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${maxResults}`,
-		{ headers: { Accept: "application/json", "X-Subscription-Token": apiKey } },
+		{ headers: { Accept: "application/json", "X-Subscription-Token": apiKey }, signal },
 	);
 	if (!res.ok) throw new Error(`Brave Search: HTTP ${res.status}`);
 	const data = (await res.json()) as {
@@ -45,11 +46,11 @@ function formatResults(results: SearchResult[], query: string): string {
 	return results.map((r, i) => `${i + 1}. **${r.title}**\n   ${r.url}\n   ${r.snippet}`).join("\n\n");
 }
 
-async function doSearch(query: string, maxResults: number): Promise<SearchResult[]> {
+async function doSearch(query: string, maxResults: number, signal?: AbortSignal): Promise<SearchResult[]> {
 	const tavilyKey = process.env.TAVILY_API_KEY;
-	if (tavilyKey) return searchTavily(query, maxResults, tavilyKey);
+	if (tavilyKey) return searchTavily(query, maxResults, tavilyKey, signal);
 	const braveKey = process.env.BRAVE_SEARCH_API_KEY;
-	if (braveKey) return searchBrave(query, maxResults, braveKey);
+	if (braveKey) return searchBrave(query, maxResults, braveKey, signal);
 	throw new Error("No search provider configured. Set TAVILY_API_KEY or BRAVE_SEARCH_API_KEY.");
 }
 
@@ -61,11 +62,11 @@ export default function (pi: ExtensionAPI) {
 			"Searches the web for up-to-date information beyond your knowledge cutoff. Prefer primary sources (official docs, papers, announcements) and corroborate key claims with multiple sources. Always include links for cited sources in your response.",
 		promptSnippet: "web_search(query) — fetch current information from the web",
 		promptGuidelines: [
-			"If unsure about a fact, search instead of guessing.",
-			"Prefer primary sources (official docs, specs, papers) over blog summaries or aggregators.",
-			"Note publication dates when recency affects relevance; prefer recent sources for time-sensitive topics.",
-			"When sources conflict, acknowledge the discrepancy and note which seems more authoritative.",
-			"Always cite sources inline and include links in your final response.",
+			"Use web_search when you are unsure about a fact instead of guessing.",
+			"When using web_search, prefer primary sources (official docs, specs, papers) over blog summaries or aggregators.",
+			"When using web_search for time-sensitive topics, note publication dates and prefer recent sources.",
+			"When web_search sources conflict, acknowledge the discrepancy and note which seems more authoritative.",
+			"When using web_search, cite sources inline and include links in your final response.",
 		],
 		parameters: Type.Object({
 			query: Type.String({ description: "Web search query" }),
@@ -78,13 +79,12 @@ export default function (pi: ExtensionAPI) {
 				}),
 			),
 		}),
-		async execute(_id, { query, maxResults }, _signal, _onUpdate, _ctx): Promise<AgentToolResult<SearchResult[]>> {
-			const results = await doSearch(query, maxResults ?? 5);
+		async execute(_id, { query, maxResults }, signal, _onUpdate, _ctx): Promise<AgentToolResult<SearchResult[]>> {
+			const results = await doSearch(query, maxResults ?? 5, signal);
 			return {
 				content: [{ type: "text", text: formatResults(results, query) }],
 				details: results,
 			};
 		},
 	});
-
 }


### PR DESCRIPTION
## Summary

- Adds a `web_search` native tool to the pi coding agent via a TypeScript extension
- Supports Tavily (default) and Brave Search as providers, selected by env var (`TAVILY_API_KEY` / `BRAVE_SEARCH_API_KEY`)
- Includes tool description and prompt guidelines drawn from oh-my-pi's web search implementation

## Test plan

- [ ] Set `TAVILY_API_KEY` and start `pi` — verify `web_search` appears in available tools
- [ ] Ask pi a question requiring current information and confirm it calls `web_search`
- [ ] Unset `TAVILY_API_KEY`, set `BRAVE_SEARCH_API_KEY` — confirm Brave fallback works
- [ ] Unset both keys — confirm error message is surfaced cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- branch-stack-start -->

<!-- branch-stack-end -->
