### PR TITLE
docs(git-town): clarify sync command mapping

### DIFF
--- a/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
+++ b/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
@@ -29,11 +29,13 @@ Default branch naming rules:
 
 ### Command Mapping
 
-| Instead of                          | Use                               |
-| ----------------------------------- | --------------------------------- |
-| `git checkout -b short-description` | `git town hack short-description` |
-| `git pull && git rebase main`       | `git town sync`                   |
-| `gh pr create`                      | `git town propose`                |
+| Instead of                                   | Use                               |
+| -------------------------------------------- | --------------------------------- |
+| `git checkout -b short-description`          | `git town hack short-description` |
+| `git pull && git rebase main`                | `git town sync`                   |
+| `git push`                                   | `git town sync`                   |
+| `git push --force-with-lease` after an amend | `git town sync`                   |
+| `gh pr create`                               | `git town propose`                |
 
 ### Shipping Work
 


### PR DESCRIPTION
## Summary
- add command mappings from raw git push commands to git town sync
- clarify that git town sync handles force-with-lease after amended or rebased history

## Verification
- git diff --check

<!-- branch-stack-start -->

<!-- branch-stack-end -->
