### PR TITLE
feat(pi): add clear TUI command

### DIFF
--- a/homes/_modules/developer/ai-agents/pi/extensions/clear.ts
+++ b/homes/_modules/developer/ai-agents/pi/extensions/clear.ts
@@ -1,0 +1,50 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { Component, TUI } from "@mariozechner/pi-tui";
+
+type ClearableComponent = { clear?: () => void };
+
+type TuiRoot = TUI & {
+	children?: ClearableComponent[];
+};
+
+const emptyComponent: Component = {
+	render: () => [],
+	invalidate: () => {},
+};
+
+async function clear(ctx: ExtensionContext) {
+	if (!ctx.hasUI) return;
+
+	await ctx.ui.custom<void>((tui, _theme, _keybindings, done) => {
+		// pi's root TUI children are ordered as:
+		// header, chat, pending messages, status, widgets, editor, widgets, footer.
+		// Clearing child 1 drops the visible chat/message buffer while preserving
+		// the current session history on disk and in context.
+		const root = tui as TuiRoot;
+		const chatContainer = root.children?.[1];
+
+		if (chatContainer && typeof chatContainer.clear === "function") {
+			chatContainer.clear();
+		}
+
+		// Force a full redraw so pi-tui clears viewport + scrollback and redraws
+		// the remaining UI from its new component tree.
+		tui.requestRender(true);
+		done();
+		return emptyComponent;
+	});
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerShortcut("ctrl+l", {
+		description: "Clear TUI buffer",
+		handler: clear,
+	});
+
+	pi.registerCommand("clear", {
+		description: "Clear the visible TUI message buffer",
+		handler: async (_args, ctx) => {
+			await clear(ctx);
+		},
+	});
+}

--- a/homes/_modules/developer/ai-agents/pi/keybindings.json
+++ b/homes/_modules/developer/ai-agents/pi/keybindings.json
@@ -1,3 +1,6 @@
 {
-  "app.thinking.cycle": ["ctrl+shift+t"]
+  "app.thinking.cycle": ["ctrl+shift+t"],
+  "app.model.select": [],
+  "app.model.cycleForward": [],
+  "app.model.cycleBackward": []
 }


### PR DESCRIPTION
## Summary
- add a Pi extension that provides /clear and Ctrl+L for clearing the visible TUI message buffer
- preserve session history and model context while clearing the rendered chat container
- unbind built-in model selection/cycling shortcuts that conflict with the clear workflow

## Verification
- ran python -m json.tool homes/_modules/developer/ai-agents/pi/keybindings.json
- cherry-picked the change onto a fresh feature branch from main

<!-- branch-stack-start -->

<!-- branch-stack-end -->
