### PR TITLE
feat: add sqlit-tui

### DIFF
--- a/homes/_modules/developer/default.nix
+++ b/homes/_modules/developer/default.nix
@@ -15,6 +15,7 @@
         agor
       ]
       ++ [
+        sqlit-tui
         coursier
         delta
         age

--- a/homes/_modules/linux/default.nix
+++ b/homes/_modules/linux/default.nix
@@ -16,6 +16,7 @@
         "Videos"
         ".local/bin"
         ".local/share/nix" # trusted settings and repl history
+        ".local/share/keyrings"
         ".ssh"
       ];
     };

--- a/hosts/common/base/default.nix
+++ b/hosts/common/base/default.nix
@@ -68,7 +68,10 @@
     usbutils
   ];
 
-  services.envfs.enable = true;
+  services = {
+    envfs.enable = true;
+    gnome.gnome-keyring.enable = true;
+  };
 
   hardware.enableRedistributableFirmware = true;
   networking.domain = "toskbot.xyz";

--- a/hosts/common/optional/greetd.nix
+++ b/hosts/common/optional/greetd.nix
@@ -52,4 +52,6 @@ in {
     enable = true;
     settings.default_session.command = sway-kiosk (lib.getExe config.programs.regreet.package);
   };
+
+  security.pam.services.greetd.enableGnomeKeyring = true;
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -29,6 +29,23 @@
       pi-coding-agent = final.callPackage ../pkgs/pi-coding-agent {};
     };
 
+  sqlit-tui = final: prev: {
+    sqlit-tui = prev.sqlit-tui.overridePythonAttrs (finalAttrs: previousAttrs: {
+      version = "1.4.0";
+      src = final.fetchFromGitHub {
+        owner = "Maxteabag";
+        repo = "sqlit";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-lcZe7EiN/wZllRO7KnXryoeGiUVBhSE4AYaRniZV6Cw=";
+      };
+      dependencies =
+        previousAttrs.dependencies
+        ++ [
+          final.python3Packages.snowflake-connector-python
+        ];
+    });
+  };
+
   # access stable packages as pkgs.stable
   stable-packages = final: _prev: {
     stable = import inputs.nixpkgs-stable {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -38,11 +38,14 @@
         tag = "v${finalAttrs.version}";
         hash = "sha256-lcZe7EiN/wZllRO7KnXryoeGiUVBhSE4AYaRniZV6Cw=";
       };
-      dependencies =
-        previousAttrs.dependencies
+      dependencies = final.lib.unique (previousAttrs.dependencies
         ++ [
+          final.python3Packages.duckdb
+          final.python3Packages.google-cloud-bigquery
+          final.python3Packages.pyathena
           final.python3Packages.snowflake-connector-python
-        ];
+          final.python3Packages.trino-python-client
+        ]);
     });
   };
 


### PR DESCRIPTION
## Summary
- add an overlay for sqlit-tui 1.4.0
- include Snowflake, Trino, Athena, DuckDB, and BigQuery Python drivers
- install sqlit-tui in developer home packages for Linux and macOS hosts
- enable GNOME Keyring/Secret Service for Linux hosts and persist keyring data across impermanent boots

## Verification
- nix fmt overlays/default.nix homes/_modules/developer/default.nix homes/_modules/linux/default.nix hosts/common/base/default.nix hosts/common/optional/greetd.nix
- nix eval .#nixosConfigurations.ot-desktop.config.system.build.toplevel.drvPath
- nix eval .#nixosConfigurations.ot-framework.config.system.build.toplevel.drvPath
- evaluated sqlit-tui dependencies include duckdb, google-cloud-bigquery, pyathena, snowflake-connector-python, and trino-python-client