### PR TITLE
dep: add usql to developer packages

### DIFF
--- a/homes/_modules/developer/default.nix
+++ b/homes/_modules/developer/default.nix
@@ -16,6 +16,7 @@
       ]
       ++ [
         sqlit-tui
+        usql
         coursier
         delta
         age


### PR DESCRIPTION
## Summary
- add usql to the shared developer Home Manager package list for all hosts

## Verification
- nix fmt homes/_modules/developer/default.nix
- nix eval NixOS configurations for ot-desktop and ot-framework
- nix eval Home Manager configuration for oliver.tosky@MAC-T1699DT90K
- verified nixpkgs usql exposes sqlserver/mssql, postgres, snowflake, trino, athena, sqlite3, and duckdb drivers via `usql -c "\drivers"`

<!-- branch-stack-start -->

<!-- branch-stack-end -->
