### PR TITLE
docs(ai-agents): prefer deps for package changes

### DIFF
--- a/homes/_modules/developer/ai-agents/instructions.md
+++ b/homes/_modules/developer/ai-agents/instructions.md
@@ -16,7 +16,6 @@ You and the user share the same workspace. Work pragmatically, make the smallest
 ## Git Safety
 
 - Commit messages must use Conventional Commits.
-- Before choosing a commit or PR title type, inspect repository-specific conventions when available: `CONTRIBUTING.md`, `README.md`, commit tooling such as `cog.toml`, and recent commit history.
 - Use `deps` for dependency and package additions, removals, or updates, including Nix package list changes and flake updates.
 - Never discard, reset, or overwrite user changes unless explicitly asked.
 - Do not amend commits unless explicitly requested.

--- a/homes/_modules/developer/ai-agents/instructions.md
+++ b/homes/_modules/developer/ai-agents/instructions.md
@@ -16,6 +16,8 @@ You and the user share the same workspace. Work pragmatically, make the smallest
 ## Git Safety
 
 - Commit messages must use Conventional Commits.
+- Before choosing a commit or PR title type, inspect repository-specific conventions when available: `CONTRIBUTING.md`, `README.md`, commit tooling such as `cog.toml`, and recent commit history.
+- Use `deps` for dependency and package additions, removals, or updates, including Nix package list changes and flake updates.
 - Never discard, reset, or overwrite user changes unless explicitly asked.
 - Do not amend commits unless explicitly requested.
 - Do not force-push unless explicitly requested, and never force-push to main or master.
@@ -36,11 +38,12 @@ You and the user share the same workspace. Work pragmatically, make the smallest
 
 - Before creating a pull request, check the repository's `CONTRIBUTING.md` and `README.md` for project-specific PR title guidance. Follow those guidelines if they conflict with these defaults.
 - Otherwise, pull request titles must use Conventional Commits: `type(scope): summary`, `type: summary`, or `type!: summary`.
-- Allowed PR title types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`.
+- Allowed PR title types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `deps`, `build`, `ci`, `perf`, `revert`.
 - Scopes are optional but encouraged when they add useful context.
 - Synthesize the PR title from the actual diff, not just the branch name or first commit.
 - Make your best call on title type/scope without asking; the user can edit the PR later.
-- Use `chore` for dependency, Nix, and routine maintenance updates unless another type is clearly more accurate.
+- Use `deps` for dependency and package additions, removals, or updates, including Nix package list changes and flake updates.
+- Use `chore` for routine maintenance that is not dependency or package related unless another type is clearly more accurate.
 
 ## Reviews
 

--- a/homes/_modules/developer/ai-agents/instructions.md
+++ b/homes/_modules/developer/ai-agents/instructions.md
@@ -16,7 +16,6 @@ You and the user share the same workspace. Work pragmatically, make the smallest
 ## Git Safety
 
 - Commit messages must use Conventional Commits.
-- Use `deps` for dependency and package additions, removals, or updates, including Nix package list changes and flake updates.
 - Never discard, reset, or overwrite user changes unless explicitly asked.
 - Do not amend commits unless explicitly requested.
 - Do not force-push unless explicitly requested, and never force-push to main or master.

--- a/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
+++ b/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
@@ -63,7 +63,6 @@ PR title rules:
 - Scopes are optional but encouraged when useful.
 - Synthesize the title from the actual diff, not just the branch name or first commit.
 - Make the best type/scope call without asking; the user can edit the PR later.
-- Before choosing a type, inspect repository-specific conventions when available: `CONTRIBUTING.md`, `README.md`, commit tooling such as `cog.toml`, and recent commit history.
 - Use `deps` for dependency and package additions, removals, or updates, including Nix package list changes and flake updates.
 - Use `chore` for routine maintenance that is not dependency or package related unless another type is clearly more accurate.
 

--- a/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
+++ b/homes/_modules/developer/ai-agents/skills/git-town/SKILL.md
@@ -59,11 +59,13 @@ git town propose --title "feat(scope): description" --body "PR body here"
 
 PR title rules:
 
-- Use one of: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`.
+- Use one of: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `deps`, `build`, `ci`, `perf`, `revert`.
 - Scopes are optional but encouraged when useful.
 - Synthesize the title from the actual diff, not just the branch name or first commit.
 - Make the best type/scope call without asking; the user can edit the PR later.
-- Use `chore` for dependency, Nix, and routine maintenance updates unless another type is clearly more accurate.
+- Before choosing a type, inspect repository-specific conventions when available: `CONTRIBUTING.md`, `README.md`, commit tooling such as `cog.toml`, and recent commit history.
+- Use `deps` for dependency and package additions, removals, or updates, including Nix package list changes and flake updates.
+- Use `chore` for routine maintenance that is not dependency or package related unless another type is clearly more accurate.
 
 Common flags:
 


### PR DESCRIPTION
## Summary
- add `deps` to allowed agent PR title types
- tell agents to inspect repo commit conventions before choosing types
- prefer `deps` for dependency/package/Nix package changes and reserve `chore` for other maintenance

## Verification
- git diff --check

<!-- branch-stack-start -->

<!-- branch-stack-end -->
