### PR TITLE
fix(terminal): restore clipboard behavior

### DIFF
--- a/homes/_modules/shell/zellij/default.nix
+++ b/homes/_modules/shell/zellij/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }: {
@@ -8,9 +9,16 @@
     enableBashIntegration = true;
     enableZshIntegration = true;
     enableFishIntegration = true;
-    settings = {
-      support_kitty_keyboard_protocol = true;
-      show_startup_tips = false;
-    };
+    settings =
+      {
+        support_kitty_keyboard_protocol = true;
+        show_startup_tips = false;
+      }
+      // lib.optionalAttrs pkgs.stdenv.isLinux {
+        copy_command = "${pkgs.wl-clipboard}/bin/wl-copy";
+      }
+      // lib.optionalAttrs pkgs.stdenv.isDarwin {
+        copy_command = "pbcopy";
+      };
   };
 }

--- a/homes/_modules/terminal/wezterm/wezterm.lua
+++ b/homes/_modules/terminal/wezterm/wezterm.lua
@@ -16,7 +16,6 @@ return {
 	enable_kitty_keyboard = true,
 	keys = {
 		{ key = "V", mods = "CTRL", action = wezterm.action.PasteFrom("Clipboard") },
-		{ key = "V", mods = "CTRL", action = wezterm.action.PasteFrom("PrimarySelection") },
 		{ key = "Enter", mods = "SHIFT", action = wezterm.action({ SendString = "\x1b\r" }) },
 	},
 

--- a/homes/_modules/terminal/wezterm/wezterm.lua
+++ b/homes/_modules/terminal/wezterm/wezterm.lua
@@ -15,7 +15,6 @@ return {
 	enable_wayland = (hostname == "ot-framework" and true or false),
 	enable_kitty_keyboard = true,
 	keys = {
-		{ key = "V", mods = "CTRL", action = wezterm.action.PasteFrom("Clipboard") },
 		{ key = "Enter", mods = "SHIFT", action = wezterm.action({ SendString = "\x1b\r" }) },
 	},
 

--- a/homes/_modules/terminal/wezterm/wezterm.lua
+++ b/homes/_modules/terminal/wezterm/wezterm.lua
@@ -15,6 +15,8 @@ return {
 	enable_wayland = (hostname == "ot-framework" and true or false),
 	enable_kitty_keyboard = true,
 	keys = {
+		{ key = "V", mods = "CTRL", action = wezterm.action.DisableDefaultAssignment },
+		{ key = "V", mods = "SHIFT|CTRL", action = wezterm.action.PasteFrom("Clipboard") },
 		{ key = "Enter", mods = "SHIFT", action = wezterm.action({ SendString = "\x1b\r" }) },
 	},
 


### PR DESCRIPTION
## Summary
- configure Zellij to call native clipboard tools instead of relying on OSC52
- use wl-copy on Linux and pbcopy on macOS
- make WezTerm paste from the clipboard with Ctrl+Shift+V while leaving Ctrl+V available for terminal apps like fzf

## Verification
- nix fmt homes/_modules/shell/zellij/default.nix
- nix fmt homes/_modules/terminal/wezterm/wezterm.lua
- printf test token through wl-copy and wl-paste
- manually verified Zellij copy and WezTerm paste works
