### PR TITLE
fix(voxtype): show recording notifications

### DIFF
--- a/homes/_modules/desktop/common/wayland-wm/voxtype.nix
+++ b/homes/_modules/desktop/common/wayland-wm/voxtype.nix
@@ -74,8 +74,8 @@ in {
       pre_type_delay_ms = 0
 
       [output.notification]
-      on_recording_start = false
-      on_recording_stop = false
+      on_recording_start = true
+      on_recording_stop = true
       on_transcription = true
 
       [status]


### PR DESCRIPTION
## Summary
- Enable Voxtype notifications when recording starts and stops.
- Keep transcription notifications enabled.

## Why
F9 push-to-talk can work without visible feedback when start/stop notifications are disabled, making it look like recording never started.

## Verification
- nix fmt -- --check homes/_modules/desktop/common/wayland-wm/voxtype.nix
- nix eval --raw '.#nixosConfigurations.ot-framework.config.home-manager.users.olivertosky.xdg.configFile."voxtype/config.toml".text' | rg -n 'on_recording_start|on_recording_stop'

<!-- branch-stack-start -->

<!-- branch-stack-end -->
