### PR TITLE
fix(pi): bind ctrl-n to new session

### DIFF
--- a/homes/_modules/developer/ai-agents/pi/keybindings.json
+++ b/homes/_modules/developer/ai-agents/pi/keybindings.json
@@ -1,5 +1,7 @@
 {
   "app.thinking.cycle": ["ctrl+shift+t"],
+  "app.session.new": ["ctrl+n"],
+  "app.session.toggleNamedFilter": [],
   "app.model.select": [],
   "app.model.cycleForward": [],
   "app.model.cycleBackward": [],


### PR DESCRIPTION
## Summary
- Bind Ctrl+N to Pi's new session action.
- Unbind the named-session filter shortcut to avoid conflicting with Ctrl+N.

## Verification
- python3 -m json.tool homes/_modules/developer/ai-agents/pi/keybindings.json
- nix eval --raw '.#nixosConfigurations.ot-framework.config.home-manager.users.olivertosky.home.file.".pi/agent/keybindings.json".source' | xargs rg -n 'app.session.new|app.session.toggleNamedFilter'

<!-- branch-stack-start -->

<!-- branch-stack-end -->
