### PR TITLE
deps(home): add image tools

### DIFF
--- a/homes/_modules/extra/default.nix
+++ b/homes/_modules/extra/default.nix
@@ -14,6 +14,8 @@ in {
       xournalpp
 
       gimp-with-plugins
+      imagemagick
+      libresprite
 
       calibre
       sonixd


### PR DESCRIPTION
## Summary
- Add ImageMagick and LibreSprite to the extra home packages

## Verification
- nix fmt homes/_modules/extra/default.nix
- nix eval confirmed pkgs.imagemagick and pkgs.libresprite exist

<!-- branch-stack-start -->

<!-- branch-stack-end -->
