### PR TITLE
feat(pi): configure pi-emote fork

### DIFF
--- a/homes/_modules/developer/ai-agents/default.nix
+++ b/homes/_modules/developer/ai-agents/default.nix
@@ -6,6 +6,9 @@
 }: let
   nixConfigProject = "${config.home.homeDirectory}/personal/nix-config";
   claudeStatusline = "${config.home.homeDirectory}/.local/bin/claude-statusline";
+  localPiEmoteFork = "${config.home.homeDirectory}/oss/pi-emote";
+  piEmotePackage = "git:github.com/otosky/pi-emote@main";
+  previousPiEmotePackages = ["file:${localPiEmoteFork}"];
 
   skillTargets = {
     ".claude/skills" = {
@@ -80,6 +83,43 @@ in {
         };
       };
     };
+
+  home.activation.configurePiPackages = lib.hm.dag.entryAfter ["writeBoundary"] ''
+    package=${lib.escapeShellArg piEmotePackage}
+    previous_packages=${lib.escapeShellArg (builtins.toJSON previousPiEmotePackages)}
+    settings_path="$HOME/.pi/agent/settings.json"
+    settings_dir="$(${pkgs.coreutils}/bin/dirname "$settings_path")"
+    ${pkgs.coreutils}/bin/mkdir -p "$settings_dir"
+
+    tmp="$(${pkgs.coreutils}/bin/mktemp "$settings_dir/settings.json.tmp.XXXXXX")"
+    if [ -e "$settings_path" ]; then
+      if ! ${pkgs.jq}/bin/jq -e 'type == "object"' "$settings_path" >/dev/null; then
+        echo "warning: leaving $settings_path unchanged; expected a JSON object" >&2
+        ${pkgs.coreutils}/bin/rm -f "$tmp"
+        exit 0
+      fi
+      input="$settings_path"
+    else
+      input="$tmp.input"
+      printf '{}\n' > "$input"
+    fi
+
+    ${pkgs.jq}/bin/jq \
+      --arg package "$package" \
+      --argjson previous_packages "$previous_packages" \
+      '.packages = (if (.packages | type) == "array" then (.packages | map(select(. as $existing | ($previous_packages | index($existing) | not))) | if any(. == $package) then . else . + [$package] end) else [$package] end)' \
+      "$input" > "$tmp"
+
+    if [ "$input" != "$settings_path" ]; then
+      ${pkgs.coreutils}/bin/rm -f "$input"
+    fi
+
+    if [ -e "$settings_path" ] && ${pkgs.coreutils}/bin/cmp -s "$settings_path" "$tmp"; then
+      ${pkgs.coreutils}/bin/rm -f "$tmp"
+    else
+      ${pkgs.coreutils}/bin/mv "$tmp" "$settings_path"
+    fi
+  '';
 
   home.activation.configureClaudeStatusline = lib.hm.dag.entryAfter ["writeBoundary"] ''
     export CLAUDE_STATUSLINE_COMMAND=${lib.escapeShellArg claudeStatusline}

--- a/homes/_modules/developer/ai-agents/pi/extensions/pi-emote/config.json
+++ b/homes/_modules/developer/ai-agents/pi/extensions/pi-emote/config.json
@@ -1,0 +1,8 @@
+{
+  "emotes": [
+    {
+      "model": "*",
+      "emote-set": "chef"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Pi to install the otosky pi-emote fork through Home Manager activation
- remove the previous local file-based pi-emote package entry when present
- add the chef emote extension configuration

## Verification
- nix fmt -- --check homes/_modules/developer/ai-agents/default.nix
- nix eval --raw '.#homeConfigurations."oliver.tosky@MAC-T1699DT90K".activationPackage.drvPath'

<!-- branch-stack-start -->

<!-- branch-stack-end -->
