### PR TITLE
chore(terminal): stop auto-starting zellij

### DIFF
--- a/homes/_modules/shell/zellij/default.nix
+++ b/homes/_modules/shell/zellij/default.nix
@@ -6,9 +6,9 @@
 }: {
   programs.zellij = {
     enable = true;
-    enableBashIntegration = true;
-    enableZshIntegration = true;
-    enableFishIntegration = true;
+    enableBashIntegration = false;
+    enableZshIntegration = false;
+    enableFishIntegration = false;
     settings =
       {
         support_kitty_keyboard_protocol = true;

--- a/homes/_modules/terminal/wezterm/wezterm.lua
+++ b/homes/_modules/terminal/wezterm/wezterm.lua
@@ -18,6 +18,8 @@ return {
 		{ key = "V", mods = "CTRL", action = wezterm.action.DisableDefaultAssignment },
 		{ key = "V", mods = "SHIFT|CTRL", action = wezterm.action.PasteFrom("Clipboard") },
 		{ key = "Enter", mods = "SHIFT", action = wezterm.action({ SendString = "\x1b\r" }) },
+		{ key = "v", mods = "CTRL|ALT", action = wezterm.action.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
+		{ key = "h", mods = "CTRL|ALT", action = wezterm.action.SplitVertical({ domain = "CurrentPaneDomain" }) },
 	},
 
 	-- Mousing bindings


### PR DESCRIPTION
## Summary
- keep zellij installed but disable shell integrations that auto-start it
- add Ctrl+Alt+h/v wezterm pane split bindings

## Verification
- alejandra --check homes/_modules/shell/zellij/default.nix
- wezterm --config-file homes/_modules/terminal/wezterm/wezterm.lua show-keys --lua

<!-- branch-stack-start -->

<!-- branch-stack-end -->
