### PR TITLE
chore(codex): configure macOS feature flags

### DIFF
--- a/homes/_modules/developer/ai-agents/default.nix
+++ b/homes/_modules/developer/ai-agents/default.nix
@@ -55,6 +55,14 @@ in {
           personality = "pragmatic"
           web_search = "cached"
 
+          ${lib.optionalString pkgs.stdenv.isDarwin ''
+            [features]
+            fast_mode = false
+            apps = false
+
+            [plugins."superpowers@openai-curated"]
+            enabled = true
+          ''}
           [agents]
           max_threads = 6
           max_depth = 1


### PR DESCRIPTION
## Summary
- disable Codex fast mode and apps on Darwin hosts
- enable the Superpowers plugin from the OpenAI curated marketplace on Darwin hosts

<!-- branch-stack-start -->

<!-- branch-stack-end -->

