### PR TITLE
fix(framework): configure clamshell mode

### DIFF
--- a/homes/_modules/desktop/hyprland.nix
+++ b/homes/_modules/desktop/hyprland.nix
@@ -7,46 +7,89 @@
   wallpaper = "/etc/_wallpapers/milad-fakurian-JrMz6hVQeu4-unsplash.jpg";
   gifWallpaper = "/home/olivertosky/Downloads/midnight.gif";
   pactl = lib.getExe' pkgs.pulseaudio "pactl";
-  hyprlandClamshell = pkgs.writeShellApplication {
-    name = "hyprland-clamshell";
+  hyprlandDisplayProfile = pkgs.writeShellApplication {
+    name = "hyprland-display-profile";
     runtimeInputs = [
       config.wayland.windowManager.hyprland.package
+      pkgs.coreutils
       pkgs.jq
+      pkgs.socat
       pkgs.systemd
     ];
     text = ''
       set -euo pipefail
 
-      action="''${1:-}"
-      internal_monitor="$(
-        hyprctl monitors all -j \
-          | jq -r '[.[] | select(.name | test("^(eDP|LVDS|DSI)-"))][0].name // empty'
-      )"
-      active_external_monitors="$(
-        hyprctl monitors -j \
-          | jq --arg internal "$internal_monitor" '[.[] | select(.name != $internal)] | length'
-      )"
+      internal_monitor=""
+      external_monitor=""
 
-      case "$action" in
-        close)
-          if [[ -n "$internal_monitor" && "$active_external_monitors" -gt 0 ]]; then
-            hyprctl keyword monitor "$internal_monitor,disable"
-          else
-            systemctl suspend
-          fi
-          ;;
-        open)
+      detect_monitors() {
+        local all_monitors
+
+        all_monitors="$(hyprctl monitors all -j)"
+        internal_monitor="$(
+          jq -r '[.[] | select(.name | test("^(eDP|LVDS|DSI)-"))][0].name // empty' \
+            <<< "$all_monitors"
+        )"
+        external_monitor="$(
+          jq -r --arg internal "$internal_monitor" \
+            '[.[] | select(.name != $internal and (.name | test("^(eDP|LVDS|DSI)-") | not))][0].name // empty' \
+            <<< "$all_monitors"
+        )"
+      }
+
+      apply_profile() {
+        detect_monitors
+
+        if [[ -n "$external_monitor" ]]; then
+          hyprctl keyword monitor "$external_monitor,preferred,0x0,1"
           if [[ -n "$internal_monitor" ]]; then
-            if [[ "$active_external_monitors" -gt 0 ]]; then
-              hyprctl keyword monitor "$internal_monitor,preferred,auto,1"
-            else
-              hyprctl keyword monitor "$internal_monitor,preferred,0x0,1"
-              hyprctl dispatch movecursor 100 100
-            fi
+            hyprctl keyword monitor "$internal_monitor,disable"
           fi
+        elif [[ -n "$internal_monitor" ]]; then
+          hyprctl keyword monitor "$internal_monitor,preferred,0x0,1"
+        fi
+
+        hyprctl dispatch movecursor 100 100
+      }
+
+      handle_lid_close() {
+        detect_monitors
+
+        if [[ -n "$external_monitor" ]]; then
+          apply_profile
+        else
+          systemctl suspend
+        fi
+      }
+
+      watch_monitors() {
+        local socket
+
+        apply_profile
+        socket="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
+        socat -u UNIX-CONNECT:"$socket" - | while IFS= read -r event; do
+          case "$event" in
+            monitoradded*|monitorremoved*)
+              sleep 1
+              apply_profile
+              ;;
+          esac
+        done
+      }
+
+      action="''${1:-apply}"
+      case "$action" in
+        apply | open)
+          apply_profile
+          ;;
+        close)
+          handle_lid_close
+          ;;
+        watch)
+          watch_monitors
           ;;
         *)
-          echo "usage: hyprland-clamshell {open|close}" >&2
+          echo "usage: hyprland-display-profile {apply|open|close|watch}" >&2
           exit 2
           ;;
       esac
@@ -114,6 +157,7 @@ in {
       exec-once = [
         "${pkgs.swaynotificationcenter}/bin/swaync"
         "${pkgs.awww}/bin/awww-daemon"
+        "${lib.getExe hyprlandDisplayProfile} watch"
       ];
       # exec = ["${pkgs.swaybg}/bin/swaybg -i ${wallpaper} --mode fill"];
       exec = ["${pkgs.awww}/bin/awww img ${gifWallpaper}"];
@@ -240,8 +284,8 @@ in {
         ];
 
       bindl = [
-        ", switch:on:Lid Switch, exec, ${lib.getExe hyprlandClamshell} close"
-        ", switch:off:Lid Switch, exec, ${lib.getExe hyprlandClamshell} open"
+        ", switch:on:Lid Switch, exec, ${lib.getExe hyprlandDisplayProfile} close"
+        ", switch:off:Lid Switch, exec, ${lib.getExe hyprlandDisplayProfile} open"
       ];
     };
   };

--- a/homes/_modules/desktop/hyprland.nix
+++ b/homes/_modules/desktop/hyprland.nix
@@ -7,6 +7,51 @@
   wallpaper = "/etc/_wallpapers/milad-fakurian-JrMz6hVQeu4-unsplash.jpg";
   gifWallpaper = "/home/olivertosky/Downloads/midnight.gif";
   pactl = lib.getExe' pkgs.pulseaudio "pactl";
+  hyprlandClamshell = pkgs.writeShellApplication {
+    name = "hyprland-clamshell";
+    runtimeInputs = [
+      config.wayland.windowManager.hyprland.package
+      pkgs.jq
+      pkgs.systemd
+    ];
+    text = ''
+      set -euo pipefail
+
+      action="''${1:-}"
+      internal_monitor="$(
+        hyprctl monitors all -j \
+          | jq -r '[.[] | select(.name | test("^(eDP|LVDS|DSI)-"))][0].name // empty'
+      )"
+      active_external_monitors="$(
+        hyprctl monitors -j \
+          | jq --arg internal "$internal_monitor" '[.[] | select(.name != $internal)] | length'
+      )"
+
+      case "$action" in
+        close)
+          if [[ -n "$internal_monitor" && "$active_external_monitors" -gt 0 ]]; then
+            hyprctl keyword monitor "$internal_monitor,disable"
+          else
+            systemctl suspend
+          fi
+          ;;
+        open)
+          if [[ -n "$internal_monitor" ]]; then
+            if [[ "$active_external_monitors" -gt 0 ]]; then
+              hyprctl keyword monitor "$internal_monitor,preferred,auto,1"
+            else
+              hyprctl keyword monitor "$internal_monitor,preferred,0x0,1"
+              hyprctl dispatch movecursor 100 100
+            fi
+          fi
+          ;;
+        *)
+          echo "usage: hyprland-clamshell {open|close}" >&2
+          exit 2
+          ;;
+      esac
+    '';
+  };
 in {
   imports = [
     ./common
@@ -193,6 +238,11 @@ in {
         [
           "SUPER, W, exec, ${lib.getExe pkgs.networkmanager_dmenu}"
         ];
+
+      bindl = [
+        ", switch:on:Lid Switch, exec, ${lib.getExe hyprlandClamshell} close"
+        ", switch:off:Lid Switch, exec, ${lib.getExe hyprlandClamshell} open"
+      ];
     };
   };
 }

--- a/homes/_modules/desktop/hyprland.nix
+++ b/homes/_modules/desktop/hyprland.nix
@@ -7,94 +7,7 @@
   wallpaper = "/etc/_wallpapers/milad-fakurian-JrMz6hVQeu4-unsplash.jpg";
   gifWallpaper = "/home/olivertosky/Downloads/midnight.gif";
   pactl = lib.getExe' pkgs.pulseaudio "pactl";
-  hyprlandDisplayProfile = pkgs.writeShellApplication {
-    name = "hyprland-display-profile";
-    runtimeInputs = [
-      config.wayland.windowManager.hyprland.package
-      pkgs.coreutils
-      pkgs.jq
-      pkgs.socat
-      pkgs.systemd
-    ];
-    text = ''
-      set -euo pipefail
-
-      internal_monitor=""
-      external_monitor=""
-
-      detect_monitors() {
-        local all_monitors
-
-        all_monitors="$(hyprctl monitors all -j)"
-        internal_monitor="$(
-          jq -r '[.[] | select(.name | test("^(eDP|LVDS|DSI)-"))][0].name // empty' \
-            <<< "$all_monitors"
-        )"
-        external_monitor="$(
-          jq -r --arg internal "$internal_monitor" \
-            '[.[] | select(.name != $internal and (.name | test("^(eDP|LVDS|DSI)-") | not))][0].name // empty' \
-            <<< "$all_monitors"
-        )"
-      }
-
-      apply_profile() {
-        detect_monitors
-
-        if [[ -n "$external_monitor" ]]; then
-          hyprctl keyword monitor "$external_monitor,preferred,0x0,1"
-          if [[ -n "$internal_monitor" ]]; then
-            hyprctl keyword monitor "$internal_monitor,disable"
-          fi
-        elif [[ -n "$internal_monitor" ]]; then
-          hyprctl keyword monitor "$internal_monitor,preferred,0x0,1"
-        fi
-
-        hyprctl dispatch movecursor 100 100
-      }
-
-      handle_lid_close() {
-        detect_monitors
-
-        if [[ -n "$external_monitor" ]]; then
-          apply_profile
-        else
-          systemctl suspend
-        fi
-      }
-
-      watch_monitors() {
-        local socket
-
-        apply_profile
-        socket="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
-        socat -u UNIX-CONNECT:"$socket" - | while IFS= read -r event; do
-          case "$event" in
-            monitoradded*|monitorremoved*)
-              sleep 1
-              apply_profile
-              ;;
-          esac
-        done
-      }
-
-      action="''${1:-apply}"
-      case "$action" in
-        apply | open)
-          apply_profile
-          ;;
-        close)
-          handle_lid_close
-          ;;
-        watch)
-          watch_monitors
-          ;;
-        *)
-          echo "usage: hyprland-display-profile {apply|open|close|watch}" >&2
-          exit 2
-          ;;
-      esac
-    '';
-  };
+  hyprctl = lib.getExe' config.wayland.windowManager.hyprland.package "hyprctl";
 in {
   imports = [
     ./common
@@ -114,6 +27,44 @@ in {
     hyprpicker
     hyprland-qtutils
   ];
+
+  services.kanshi = {
+    enable = true;
+    settings = [
+      {
+        output = {
+          criteria = "ASUSTek COMPUTER INC VG27B R2LMQS029617";
+          alias = "asus-vg27b";
+        };
+      }
+      {
+        profile.name = "undocked";
+        profile.outputs = [
+          {
+            criteria = "eDP-1";
+            status = "enable";
+            position = "0,0";
+          }
+        ];
+        profile.exec = "${hyprctl} dispatch movecursor 100 100";
+      }
+      {
+        profile.name = "docked";
+        profile.outputs = [
+          {
+            criteria = "eDP-1";
+            status = "disable";
+          }
+          {
+            criteria = "$asus-vg27b";
+            status = "enable";
+            position = "0,0";
+          }
+        ];
+        profile.exec = "${hyprctl} dispatch movecursor 100 100";
+      }
+    ];
+  };
 
   wayland.windowManager.hyprland = {
     enable = true;
@@ -157,7 +108,6 @@ in {
       exec-once = [
         "${pkgs.swaynotificationcenter}/bin/swaync"
         "${pkgs.awww}/bin/awww-daemon"
-        "${lib.getExe hyprlandDisplayProfile} watch"
       ];
       # exec = ["${pkgs.swaybg}/bin/swaybg -i ${wallpaper} --mode fill"];
       exec = ["${pkgs.awww}/bin/awww img ${gifWallpaper}"];
@@ -282,11 +232,6 @@ in {
         [
           "SUPER, W, exec, ${lib.getExe pkgs.networkmanager_dmenu}"
         ];
-
-      bindl = [
-        ", switch:on:Lid Switch, exec, ${lib.getExe hyprlandDisplayProfile} close"
-        ", switch:off:Lid Switch, exec, ${lib.getExe hyprlandDisplayProfile} open"
-      ];
     };
   };
 }

--- a/hosts/ot-framework/default.nix
+++ b/hosts/ot-framework/default.nix
@@ -63,6 +63,12 @@
   };
 
   services = {
+    logind.settings.Login = {
+      HandleLidSwitch = "suspend";
+      HandleLidSwitchDocked = "ignore";
+      HandleLidSwitchExternalPower = "suspend";
+    };
+
     fwupd.enable = true;
     # we need fwupd 1.9.7 to downgrade the fingerprint sensor firmware
     fwupd.package =


### PR DESCRIPTION
## Summary
- configure logind lid handling for docked and non-docked Framework use
- use kanshi for simple Wayland display profiles
- prefer the ASUS external monitor as the only active display when connected
- restore the Framework panel when undocked
- move the cursor back on-screen after display profile changes

## Verification
- nix fmt .
- nix build .#nixosConfigurations.ot-framework.config.system.build.toplevel --no-link
- inspected generated kanshi config and confirmed it uses `hyprctl`
- confirmed Hyprland sees the lid switch as `Lid Switch`

Fixes #21

<!-- branch-stack-start -->

-------------------------
- main
  - **fix(framework): configure clamshell mode** :point_left:

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->
